### PR TITLE
Update Solidus branch in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,8 @@
 
 source 'https://rubygems.org'
 
-# TODO this is the PR that is removing the functionality from Solidus.
-# Once that PR is merged in master, this can be changed.
-gem 'solidus', github: 'nebulab/solidus', branch: 'no-product-add-at-shipments'
+# currently this gem extension is compatible only with Solidus master:
+gem 'solidus', github: 'nebulab/solidus', branch: 'master'
 
 gem 'deface', require: false
 gem 'solidus_auth_devise'


### PR DESCRIPTION
Now that https://github.com/solidusio/solidus/pull/3214 is merged, Solidus branch in the Gemfile must be updated to `master`.

Until a new Solidus version will be released, only Solidus `master` supports this extension.