### PR TITLE
Remove the last remaining `Spree.routes` call

### DIFF
--- a/app/assets/javascripts/spree/backend/solidus_shipments_add_product.js
+++ b/app/assets/javascripts/spree/backend/solidus_shipments_add_product.js
@@ -50,7 +50,7 @@ addVariantFromStockLocation = function(stock_location_id, variant_id, quantity) 
    if(shipment==undefined){
     Spree.ajax({
       type: "POST",
-      url: Spree.routes.shipments_api,
+      url: Spree.pathFor('api/shipments/'),
       data: {
         shipment: {
           order_id: window.order_number


### PR DESCRIPTION
`Spree.routes` was deprecated in favor of `Spree.pathFor`. Let's replace the last legacy call, in the same fashion than what we did in commit 567d251.